### PR TITLE
Getting rid of lambda funcs

### DIFF
--- a/motornet/environment.py
+++ b/motornet/environment.py
@@ -77,8 +77,6 @@ class Environment(gym.Env, th.nn.Module):
     self.q_init = q_init
     self.goal = None
 
-    self.detach = lambda x: x.cpu().detach().numpy() if th.is_tensor(x) else x
-
     self._action_noise = action_noise
     self._obs_noise = obs_noise
     self.action_noise = 0.
@@ -107,7 +105,10 @@ class Environment(gym.Env, th.nn.Module):
 
     self.seed = None
     self._build_spaces()
-      
+
+  def detach(self, x):
+    return x.cpu().detach().numpy() if th.is_tensor(x) else x
+  
   def _build_spaces(self):
     self.action_space = gym.spaces.Box(low=0., high=1., shape=(self.effector.n_muscles,), dtype=np.float32)
 

--- a/motornet/muscle.py
+++ b/motornet/muscle.py
@@ -54,8 +54,10 @@ class Muscle(th.nn.Module):
     self.l0_se = None
     self.l0_ce = None
     self.l0_pe = None
-    self.clip_activation = lambda a: th.clip(a, self.min_activation, 1.)
     self.built = False
+
+  def clip_activation(self, a):
+    return th.clamp(a, self.min_activation, 1.)
   
   @property
   def device(self):

--- a/motornet/skeleton.py
+++ b/motornet/skeleton.py
@@ -62,11 +62,20 @@ class Skeleton(th.nn.Module):
     self.clip_position = None
     self.init = False
     self.built = False
-    self.detach = lambda x: x.cpu().detach().numpy() if th.is_tensor(x) else x
+    #self.detach = lambda x: x.cpu().detach().numpy() if th.is_tensor(x) else x
 
-    def clip(x, lb, ub): return th.min(th.max(x, lb), ub)
-    self.clip = clip
+    self.clip = self._clip
 
+  @staticmethod
+  def _clip(x, lb, ub):
+    return th.min(th.max(x, lb), ub)
+
+  def clip_method(self, x):
+    return self.clip(x, self.pos_lower_bound, self.pos_upper_bound)
+
+  def detach(self, x):
+    return x.cpu().detach().numpy() if th.is_tensor(x) else x
+  
   def build(
       self,
       timestep: float,
@@ -99,7 +108,7 @@ class Skeleton(th.nn.Module):
     self.vel_upper_bound = Parameter(th.tensor(vel_upper_bound, dtype=th.float32).reshape(1, -1), requires_grad=False)
     self.vel_lower_bound = Parameter(th.tensor(vel_lower_bound, dtype=th.float32).reshape(1, -1), requires_grad=False)
     self.dt = timestep
-    self.clip_position = lambda x: self.clip(x, self.pos_lower_bound, self.pos_upper_bound)
+    self.clip_position = self.clip_method
     self.built = True
 
   def path2cartesian(self, path_coordinates, path_fixation_body, joint_state):


### PR DESCRIPTION
Getting rid of lambda functions in environment, muscle, and skeleton.py files. This allows for these objects to be serialized in Pickle.

All provided notebooks work without issue and pickling the arm26 model works as expected.