### PR TITLE
Fix Effector.reset() crash on numpy joint_state

### DIFF
--- a/motornet/effector.py
+++ b/motornet/effector.py
@@ -184,7 +184,7 @@ class Effector(torch.nn.Module):
     joint_state: torch.Tensor | np.ndarray | None = options.get('joint_state', None)
 
     if joint_state is not None:
-      joint_state_shape = np.shape(joint_state.cpu().detach().numpy())
+      joint_state_shape = np.shape(joint_state.cpu().detach().numpy() if torch.is_tensor(joint_state) else np.array(joint_state))
       if joint_state_shape[0] > 1:
         batch_size = joint_state_shape[0]
 
@@ -525,7 +525,7 @@ class Effector(torch.nn.Module):
     if joint_state is None:
       joint0 = self.draw_random_uniform_states(batch_size=batch_size)
     else:
-      joint_state_shape = np.shape(joint_state.cpu().detach().numpy())
+      joint_state_shape = np.shape(joint_state.cpu().detach().numpy() if torch.is_tensor(joint_state) else np.array(joint_state))
       if joint_state_shape[0] > 1:
         batch_size = 1
       n_state = joint_state.shape[1]


### PR DESCRIPTION
`Effector.reset()` and `_parse_initial_joint_state()` assumed `joint_state` was always a `torch.Tensor`, calling `.cpu().detach().numpy()` on it unconditionally. This crashes with an `AttributeError` whenever `joint_state` is a numpy array, which it always is when it comes from `Environment`'s `q_init` (stored as `np.array(...)` in `Environment.__init__`, never a tensor).

Fix: guard both sites with `torch.is_tensor(joint_state)`, matching the pattern `draw_fixed_states` already uses elsewhere in the same file. No behavior change for the existing tensor path.