### PR TITLE
Fix .to(device) not propagating to nested modules

### DIFF
--- a/motornet/effector.py
+++ b/motornet/effector.py
@@ -54,7 +54,7 @@ class Effector(torch.nn.Module):
 
     super().__init__()
 
-    self._device = torch.device('cpu')
+    self.register_buffer('_device_marker', torch.empty(0), persistent=False)
     self.__name__ = name
     self.register_buffer('damping', torch.tensor(damping, dtype=torch.float32))
     self.skeleton = skeleton.to(self.device)
@@ -210,18 +210,9 @@ class Effector(torch.nn.Module):
   def np_random(self, rng: np.random.Generator):
     self._np_random = rng
 
-  def to(self, *args, **kwargs):
-    if args and isinstance(args[0], (str, torch.device)):
-      self._device = torch.device(args[0])
-    elif args and isinstance(args[0], torch.Tensor):
-      self._device = args[0].device
-    elif 'device' in kwargs:
-      self._device = torch.device(kwargs['device'])
-    return super().to(*args, **kwargs)
-
   @property
   def device(self) -> torch.device:
-    return self._device
+    return self._device_marker.device
 
   def add_muscle(self, path_fixation_body: list, path_coordinates: list, name: str | None = None, **kwargs) -> None:
     """Adds a muscle to the effector.

--- a/motornet/environment.py
+++ b/motornet/environment.py
@@ -66,9 +66,8 @@ class Environment(gym.Env, torch.nn.Module):
 
     super().__init__(**kwargs)
 
-    self._device = torch.device('cpu')
     self.__name__ = name
-    self.effector = effector.to(self.device)
+    self.effector = effector
     self.dt = self.effector.dt
     self.differentiable = differentiable
     self.max_ep_duration = max_ep_duration
@@ -481,18 +480,9 @@ class Environment(gym.Env, torch.nn.Module):
     cfg["effector"] = self.effector.get_save_config()
     return cfg
 
-  def to(self, *args, **kwargs):
-    if args and isinstance(args[0], (str, torch.device)):
-      self._device = torch.device(args[0])
-    elif args and isinstance(args[0], torch.Tensor):
-      self._device = args[0].device
-    elif 'device' in kwargs:
-      self._device = torch.device(kwargs['device'])
-    return super().to(*args, **kwargs)
-
   @property
   def device(self) -> torch.device:
-    return self._device
+    return self.effector.device
 
 
 class RandomTargetReach(Environment):

--- a/motornet/muscle.py
+++ b/motornet/muscle.py
@@ -36,7 +36,7 @@ class Muscle(torch.nn.Module):
 
     super().__init__()
 
-    self._device = torch.device('cpu')
+    self.register_buffer('_device_marker', torch.empty(0), persistent=False)
     self.input_dim = input_dim
     self.state_name = []
     self.output_dim = output_dim
@@ -57,18 +57,9 @@ class Muscle(torch.nn.Module):
   def clip_activation(self, a: torch.Tensor) -> torch.Tensor:
     return torch.clamp(a, self.min_activation, 1.)
 
-  def to(self, *args, **kwargs):
-    if args and isinstance(args[0], (str, torch.device)):
-      self._device = torch.device(args[0])
-    elif args and isinstance(args[0], torch.Tensor):
-      self._device = args[0].device
-    elif 'device' in kwargs:
-      self._device = torch.device(kwargs['device'])
-    return super().to(*args, **kwargs)
-
   @property
   def device(self) -> torch.device:
-    return self._device
+    return self._device_marker.device
 
   def build(self, timestep: float, max_isometric_force: float | list, **kwargs) -> None:
     """Build the muscle given parameters from the ``motornet.effector.Effector`` wrapper object. This should be

--- a/motornet/skeleton.py
+++ b/motornet/skeleton.py
@@ -38,7 +38,7 @@ class Skeleton(torch.nn.Module):
 
     super().__init__()
 
-    self._device = torch.device('cpu')
+    self.register_buffer('_device_marker', torch.empty(0), persistent=False)
     self.__name__ = name
     self.dof = dof
     self.space_dim = space_dim
@@ -247,18 +247,9 @@ class Skeleton(torch.nn.Module):
     """
     self.__setattr__(name, value)
 
-  def to(self, *args, **kwargs):
-    if args and isinstance(args[0], (str, torch.device)):
-      self._device = torch.device(args[0])
-    elif args and isinstance(args[0], torch.Tensor):
-      self._device = args[0].device
-    elif 'device' in kwargs:
-      self._device = torch.device(kwargs['device'])
-    return super().to(*args, **kwargs)
-
   @property
   def device(self) -> torch.device:
-    return self._device
+    return self._device_marker.device
 
 
 class PointMass(Skeleton):

--- a/tests/test_device_propagation.py
+++ b/tests/test_device_propagation.py
@@ -1,0 +1,61 @@
+"""Tests for device propagation through .to() across the Environment -> Effector -> {Muscle, Skeleton} tree.
+
+Environment, Effector, Muscle, and Skeleton each override .to() to track their own `self._device`
+bookkeeping attribute (used elsewhere as `device=self.device` when constructing new tensors).
+Calling .to(device) on a parent triggers PyTorch's internal nn.Module._apply() recursion into
+children, which correctly moves already-registered parameters/buffers -- but _apply() calls each
+child's `_apply`, not its public `.to()`, so a child's own `.to()` override (and the `self._device`
+bookkeeping it updates) is never invoked unless `.to()` is called on that child directly. Nested
+`self._device` attributes can therefore go stale relative to where the real tensors live, causing
+device-mismatch errors when the module later constructs new tensors using `device=self.device`.
+
+These tests require a non-CPU device (CUDA or MPS) to actually observe the bug, since moving
+cpu -> cpu can't expose a staleness problem. They are skipped if neither is available.
+"""
+
+import pytest
+import torch
+
+from motornet.effector import ReluPointMass24
+from motornet.environment import Environment
+
+
+def _first_available_accelerator():
+    if torch.cuda.is_available():
+        return "cuda"
+    if torch.backends.mps.is_available():
+        return "mps"
+    return None
+
+
+DEVICE = _first_available_accelerator()
+requires_accelerator = pytest.mark.skipif(
+    DEVICE is None, reason="no non-CPU device (cuda/mps) available"
+)
+
+
+@requires_accelerator
+class TestDevicePropagation:
+
+    @pytest.fixture
+    def env(self):
+        return Environment(effector=ReluPointMass24())
+
+    def test_effector_device_updates_after_env_to(self, env):
+        env.to(DEVICE)
+        assert env.effector.device.type == DEVICE
+
+    def test_muscle_device_updates_after_env_to(self, env):
+        env.to(DEVICE)
+        assert env.effector.muscle.device.type == DEVICE
+
+    def test_skeleton_device_updates_after_env_to(self, env):
+        env.to(DEVICE)
+        assert env.effector.skeleton.device.type == DEVICE
+
+    def test_reset_after_env_to_does_not_raise(self, env):
+        """End-to-end reproduction of the actual crash: reset() creates new tensors using the
+        (potentially stale) device bookkeeping of effector/muscle/skeleton, which raises a
+        device-mismatch RuntimeError against tensors that were genuinely moved by _apply()."""
+        env.to(DEVICE)
+        env.reset(options={"batch_size": 4, "deterministic": True})


### PR DESCRIPTION
Environment, Effector, Muscle, and Skeleton each track their own device via a hand-rolled `.to()` override and a private `_device` attribute. PyTorch's internal `_apply()`, which the real `.to()` uses to recurse into child modules, calls each child's `_apply()` directly rather than its public `.to()`, so this bookkeeping goes stale on every class below the one `.to()` was actually called on. Any tensor later created with `device=self.device` then lands on the wrong device relative to buffers that had already moved correctly, causing "Expected all tensors to be on the same device" errors (e.g. `env.to('cuda')` followed by `env.reset()`).

Fix: replace the manual tracking with a dedicated `_device_marker` buffer (Effector, Muscle, Skeleton), which PyTorch moves automatically like any other buffer, and derive `.device` from it. Environment has no buffers of its own, so its `.device` now delegates to `self.effector.device`.

Includes a failing-test commit reproducing the bug (skipped without a CUDA/MPS device) followed by the fix.

Note: as a side effect, constructing an Environment no longer forces its effector back onto cpu. It now preserves whatever device the effector was already on when passed in.